### PR TITLE
Origin Header Efficiency Improvements

### DIFF
--- a/roadrecon/roadtools/roadrecon/gather.py
+++ b/roadrecon/roadtools/roadrecon/gather.py
@@ -125,18 +125,14 @@ def checktoken():
         auth.tokendata = token
         if 'useragent' in token:
             auth.set_user_agent(token['useragent'])
+        if 'originheader' in token:
+            auth.set_origin_value(token['originheader'])
         if 'refreshToken' in token:
-            print("+ Attempting token refresh +")
-            #token = auth.authenticate_with_refresh(token)
-            try:
-                token = auth.authenticate_with_refresh_native(token['refreshToken'])
-            except:
-                token = auth.authenticate_with_refresh_native_v2(token['refreshToken'])
+            print("- Attempting token refresh -")
+            token = auth.authenticate_with_refresh(token)
             headers['Authorization'] = '%s %s' % (token['tokenType'], token['accessToken'])
-            #expiretime = time.time() + token['expiresIn']
-            dt = datetime.strptime(token['expiresOn'], "%Y-%m-%d %H:%M:%S")
-            expiretime = dt.timestamp()
-            print('Refreshed token')
+            expiretime = time.time() + token['expiresIn']
+            print('+ Refreshed token +')
             return True
         elif time.time() > expiretime:
             print('Access token is expired, but no access to refresh token! Dumping will fail')


### PR DESCRIPTION
Improvements to more efficiently handle adding "Origin" header to Single Page Application token refresh requests. Removed static client id, implemented a static header for adal when self.origin is set in Auth.py, updated checktoken function in gather.py to use adal authorization with refresh token instead of native, removed unnecessary comments.